### PR TITLE
DEVOPS-406: Adds custom policy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,40 @@
 # AWS KMS Key Module
 
-## Description 
+## Description
 
 This Terraform module provisions an AWS KMS (Key Management Service) key and an associated alias. It enables you to create a custom KMS key with optional key rotation and tag it with specific project and environment details.
 
-## Requirements 
+## Requirements
 
-| Name | Version | 
-|------|---------| 
-| terraform | >= 1.3.0 | 
-| aws | >= 4.0 | 
+| Name | Version |
+|------|---------|
+| terraform | >= 1.3.0 |
+| aws | >= 4.0 |
 
-## Providers 
+## Providers
 
-| Name | Version | 
-|------|---------| 
-| aws | >= 4.0 | 
+| Name | Version |
+|------|---------|
+| aws | >= 6.0 |
 
-## Inputs 
+## Inputs
 
-| Name              | Description                        | Type    | Default | Required | 
-|-------------------|------------------------------------|---------|---------|:--------:| 
-| project           | Project name                       | string  | -       | yes      | 
-| environment       | Environment name                   | string  | -       | yes      | 
-| resource_name     | Resource name created KMS for      | string  | -       | yes      | 
+| Name              | Description                        | Type    | Default | Required |
+|-------------------|------------------------------------|---------|---------|:--------:|
+| project           | Project name                       | string  | -       | yes      |
+| environment       | Environment name                   | string  | -       | yes      |
+| resource_name     | Resource name created KMS for      | string  | -       | yes      |
 | enable_key_rotation | Enable key rotation                | bool    | true    | no       |
-| tags              | tags                               | map(string)  | -  | no       | 
+| tags              | tags                               | map(string)  | {}  | no       |
+| key_policy_statements | Additional key policy statements (merged with default root statement) | list(object) | [] | no |
 
-## Outputs 
+## Outputs
 
-| Name    | Description       | 
-|---------|-------------------| 
-| key_arn | The ARN of the KMS key | 
+| Name    | Description       |
+|---------|-------------------|
+| key_arn | The ARN of the KMS key |
 
-## Usage examples 
+## Usage examples
 
 ### Example 1: Basic usage of the module
 
@@ -52,6 +53,30 @@ module "kms_key" {
 
 output "key_arn" {
   value = module.kms_key.key_arn
+}
+```
+
+### Example 2: Key with custom policy (e.g. Aurora DSQL)
+
+```hcl
+module "kms_key" {
+  source        = "github.com/opstimus/terraform-aws-kms?ref=v<RELEASE>"
+  project       = "my-project"
+  environment   = "dev"
+  resource_name = "my-dsql-key"
+
+  key_policy_statements = [
+    {
+      sid    = "Allow Aurora DSQL"
+      effect = "Allow"
+      principals = [{ type = "Service", identifiers = ["dsql.amazonaws.com"] }]
+      actions = [
+        "kms:Decrypt", "kms:GenerateDataKey", "kms:GenerateDataKeyWithoutPlaintext",
+        "kms:Encrypt", "kms:ReEncryptFrom", "kms:ReEncryptTo", "kms:DescribeKey"
+      ]
+      resources = ["*"]
+    }
+  ]
 }
 ```
 

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,46 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "main" {
+  # Root account full access (KMS best practice; avoids lockout)
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+
+  dynamic "statement" {
+    for_each = var.key_policy_statements
+    content {
+      sid    = statement.value.sid
+      effect = statement.value.effect
+      dynamic "principals" {
+        for_each = statement.value.principals
+        content {
+          type        = principals.value.type
+          identifiers = principals.value.identifiers
+        }
+      }
+      actions   = statement.value.actions
+      resources = statement.value.resources
+    }
+  }
+}
+
 resource "aws_kms_key" "main" {
   description             = "${var.resource_name} custom kms key"
   deletion_window_in_days = 7
   enable_key_rotation     = var.enable_key_rotation
   tags                    = var.tags
+}
+
+resource "aws_kms_key_policy" "main" {
+  key_id = aws_kms_key.main.id
+  policy = data.aws_iam_policy_document.main.json
 }
 
 resource "aws_kms_alias" "main" {

--- a/variables.tf
+++ b/variables.tf
@@ -26,8 +26,8 @@ variable "enable_key_rotation" {
 
 variable "key_policy_statements" {
   type = list(object({
-    sid     = optional(string, "")
-    effect  = string
+    sid    = optional(string, "")
+    effect = string
     principals = list(object({
       type        = string
       identifiers = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -23,3 +23,18 @@ variable "enable_key_rotation" {
   type    = bool
   default = true
 }
+
+variable "key_policy_statements" {
+  type = list(object({
+    sid     = optional(string, "")
+    effect  = string
+    principals = list(object({
+      type        = string
+      identifiers = list(string)
+    }))
+    actions   = list(string)
+    resources = list(string)
+  }))
+  default     = []
+  description = "Additional key policy statements merged with the default root account statement. Use for service principals (e.g. dsql.amazonaws.com) or cross-account access."
+}


### PR DESCRIPTION
Extends the KMS module to support custom key policies, allowing for fine-grained control over key access.

This addresses the need to grant specific permissions to service principals or for cross-account access, enhancing the module's flexibility and security.